### PR TITLE
Fix to gigamuga SNP check

### DIFF
--- a/R/calc.genoprob.R
+++ b/R/calc.genoprob.R
@@ -149,7 +149,10 @@ calc.genoprob = function(data, chr = "all", output.dir = ".", plot = TRUE,
       } else if(array == "gigamuga") {
 
         snps = snps[snps$tier <= 2 & snps$is.biallelic == TRUE,]
-
+        ### Inserting line to stop this part from crashing
+        ### Removing 5 lines without chromosome assignments
+        snps <- snps[-(120821:120825),]
+        
         # Make sure that the marker positions always increase.
         for(i in 2:nrow(snps)) {
           if(snps[i-1,2] == snps[i,2]) {  


### PR DESCRIPTION
This part crashes due to missing chromosome assignments - removed those 5 SNPs.